### PR TITLE
Updating WfCommons package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ requests==2.24.0
 scipy==1.5.2
 six==1.15.0
 urllib3==1.25.10
-workflowhub==0.3
+wfcommons==0.5
 zipp==3.1.0


### PR DESCRIPTION
Hello, WorkflowHub is now WfCommons (https://wfcommons.org). This PR updates the package version.